### PR TITLE
Add meeting invites functionality as per #5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'http://rubygems.org'
+gem "ri_cal"

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -177,7 +177,27 @@ class Meeting < ActiveRecord::Base
   def recipients
     [author].concat(participants).delete_if(&:nil?)
   end
-  
+   
+  def event_start_hour
+	date_string       = date.nil? ? "" : "#{date.strftime("%Y%m%d")}"
+	start_hour_string = start_hour.nil? ? "" : "#{start_hour.strftime("%H%M%S")}"
+	"#{date_string}T#{start_hour_string}" 
+  end
+
+  def event_end_hour
+	date_string     = date.nil? ? "" : "#{date.strftime("%Y%m%d")}"
+	end_hour_string = end_hour.nil? ? "" : "#{end_hour.strftime("%H%M%S")}"
+	"#{date_string}T#{end_hour_string}" 
+  end
+
+  # Returns the string of Local timezone 
+  def local_time_zone
+	zone_name = ActiveSupport::TimeZone::MAPPING.keys.find do |name|
+	  ActiveSupport::TimeZone[name].utc_offset == Time.now.utc_offset
+	end
+	ActiveSupport::TimeZone.find_tzinfo(zone_name).identifier
+  end 
+
   def display_status
     status_display_for self
   end
@@ -260,4 +280,5 @@ class Meeting < ActiveRecord::Base
       errors.add(:issue_id, :invalid)
     end
   end
+ 
 end

--- a/lib/meetings/mailer_patch.rb
+++ b/lib/meetings/mailer_patch.rb
@@ -1,4 +1,5 @@
 require Rails.root.join('lib','redmine','helpers','time_report').to_s
+require 'ri_cal'
 
 module Meetings
   
@@ -31,6 +32,46 @@ module Meetings
         @meeting = meeting
         @meeting_url = url_for(:controller => 'meetings', :action => 'show', :id => meeting)
         recipients = meeting.recipients.map(&:mail)
+
+	zone_name = ActiveSupport::TimeZone::MAPPING.keys.find do |name|
+	  ActiveSupport::TimeZone[name].utc_offset == Time.now.utc_offset
+	end
+		
+	time_zone_str  = ActiveSupport::TimeZone.find_tzinfo(zone_name).identifier
+	date_str       = "#{meeting.date.strftime("%Y%m%d")}"
+	start_time_str = "#{meeting.start_hour.strftime("%H%M%S")}"
+	end_time_str   = "#{meeting.end_hour.strftime("%H%M%S")}"
+	dt_start       = "TZID=#{time_zone_str}:#{date_str}T#{start_time_str}" 
+	dt_end         = "TZID=#{time_zone_str}:#{date_str}T#{end_time_str}" 
+	
+        cal = RiCal.Calendar do |cal|
+          cal.prodid           = "REDMINE-MEETINGS-PLUGIN"
+          cal.method_property  = ":REQUEST"
+          cal.event do |event|
+            event.dtstamp     = DateTime.now.utc
+            event.summary     = meeting.subject
+            event.description = meeting.description
+	    event.dtstart     = dt_start
+	    event.dtend       = dt_end
+            event.location    = meeting.location
+            meeting.recipients.collect.sort.each do |user|
+              event.add_attendee  user.mail
+            end
+            event.organizer   = meeting.author.mail
+            event.uid         = "B10AA0B0-0000-0000-#{"%012d" % meeting.id}"
+            event.status      = "CONFIRMED"
+            event.class_property = ":PUBLIC"
+            event.priority    = 5
+            event.transp      = "OPAQUE"
+            event.alarm do
+              description "REMINDER"
+              action "DISPLAY"
+              trigger_property ";RELATED=START:-PT5M"
+            end
+          end
+        end
+
+        attachments['invite.ics'] = {:mime_type => "text/calendar", :content => cal.to_s }
         mail :to => recipients,
           :subject => "[#{meeting.project.name} - #{l(:label_meeting)} ##{meeting.id}] #{meeting.subject}"
       end


### PR DESCRIPTION
...ing mails. Hence, the mail client can provide a way to easily pop it in the calender.

This requires the standard (http://www.ietf.org/rfc/rfc2445.txt) which is actually accomplished by use of RiCal (see http://ri-cal.rubyforge.org/, http://ri-cal.rubyforge.org/).
The Gemfile is added to deal with this.

The meeting itself has a start_hour and end_hour which is not defined for any time_zone which apperently is very critical for these calender apps - hence the timeZone assumed is that of local.

This has been tested under 2.2.x - with most times being accurate.
The timezone name and date-time-string computation seems to be a little clumsy which I am planning to clean up in next commit.

Any feedback would be welcome.

Dipan Mehta.
